### PR TITLE
Update upload and download GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,13 @@ jobs:
       - run: npm run build
       
       - name: Archive site as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: out
           path: out
 
       - name: Archive s3_website.yml as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: s3_website
           path: s3_website.yml
@@ -56,7 +56,7 @@ jobs:
           name: out
 
       - name: Retrieve s3_website.yml from artifacts
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: s3_website
 


### PR DESCRIPTION
Builds were failing, because these were deprecated. See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/